### PR TITLE
Update the installation command via fisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This plugin adds a function to print out the [fish-shell](http://fish.sh) ASCII-
 
 * Using [Fisher](https://github.com/jorgebucaran/fisher):
   ```shell
-  fisher add laughedelic/fish_logo
+  fisher install laughedelic/fish_logo
   ```
 
 * Using [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish):


### PR DESCRIPTION
As the issue at https://github.com/jorgebucaran/fisher/issues/593, 
Starting in v4.0, the 'add' command has been replaced by 'install'